### PR TITLE
Option to add keyword without adding parent keywords

### DIFF
--- a/ai_tagging.lrdevplugin/ExportServiceProvider.lua
+++ b/ai_tagging.lrdevplugin/ExportServiceProvider.lua
@@ -465,7 +465,7 @@ function exportServiceProvider.processRenderedPhotos( functionContext, exportCon
   require 'KwUtils'.getAllKeywords(true);
   -- Before continuing, we should
   -- be sure the process of populating our global variables for these has completed.
-  local timeout = 30;
+  local timeout = prefs.keyword_parsing_timeout;
   local timeWaited = LUTILS.waitForGlobal('AllKeys', timeout);
   
   if timeWaited and timeWaited < timeout then

--- a/ai_tagging.lrdevplugin/InitPlugin.lua
+++ b/ai_tagging.lrdevplugin/InitPlugin.lua
@@ -36,6 +36,8 @@ local defaultPrefValues = {
   clarifai_apikey = '',
   ignore_keyword_branches = '',
   parent_tag = '',
+  keyword_parsing_timeout = 30,
+  tag_add_keyword_parents = true, 
   image_preview_window_width = 1024,
   image_preview_window_height = 768,
   log_level = KmnUtils.LogTrace,
@@ -45,7 +47,6 @@ local defaultPrefValues = {
   tag_window_width = 1024,
   tag_window_show_probabilities = true,
   tag_window_show_services = true,
-  tag_add_keyword_parents = true,
   tag_window_sort = KmnUtils.SortProb,
   tag_window_thumbnail_size = 256,
 }

--- a/ai_tagging.lrdevplugin/InitPlugin.lua
+++ b/ai_tagging.lrdevplugin/InitPlugin.lua
@@ -45,6 +45,7 @@ local defaultPrefValues = {
   tag_window_width = 1024,
   tag_window_show_probabilities = true,
   tag_window_show_services = true,
+  tag_add_keyword_parents = true,
   tag_window_sort = KmnUtils.SortProb,
   tag_window_thumbnail_size = 256,
 }

--- a/ai_tagging.lrdevplugin/KwUtils.lua
+++ b/ai_tagging.lrdevplugin/KwUtils.lua
@@ -35,10 +35,10 @@ KwUtils.Attribution = "This plugin uses KwUtils, Lightroom keyword utilities, ©
 
 function KwUtils.addKeywordWithParents(photo, keyword)
     photo:addKeyword(keyword)
-		local parent = keyword:getParent()
-     	if parent ~= nil then
+    local parent = keyword:getParent()
+    if parent ~= nil then
         KwUtils.addKeywordWithParents(photo, parent)
-   end
+    end
 end
 
 -- Call this function with just a keyword object. This recursively calls kw:getParent,

--- a/ai_tagging.lrdevplugin/KwUtils.lua
+++ b/ai_tagging.lrdevplugin/KwUtils.lua
@@ -35,10 +35,10 @@ KwUtils.Attribution = "This plugin uses KwUtils, Lightroom keyword utilities, ©
 
 function KwUtils.addKeywordWithParents(photo, keyword)
     photo:addKeyword(keyword)
-    local parent = keyword:getParent()
-    if parent ~= nil then
+		local parent = keyword:getParent()
+     	if parent ~= nil then
         KwUtils.addKeywordWithParents(photo, parent)
-    end
+   end
 end
 
 -- Call this function with just a keyword object. This recursively calls kw:getParent,
@@ -89,6 +89,16 @@ function KwUtils.addOrRemoveKeyword(photo, keyword, state)
         KwUtils.addKeywordWithParents(photo, keyword)
     else
       -- We cannot assume parents should be removed if already there.
+        photo:removeKeyword(keyword)
+    end
+end
+
+-- Add or remove a keyword based on the "state" of the associated checkbox.
+-- (not adding keyword parents)
+function KwUtils.addOrRemoveKeywordWithoutParents(photo, keyword, state)
+    if state then
+        photo:addKeyword(keyword)
+    else
         photo:removeKeyword(keyword)
     end
 end

--- a/ai_tagging.lrdevplugin/PluginInfoProvider.lua
+++ b/ai_tagging.lrdevplugin/PluginInfoProvider.lua
@@ -111,11 +111,11 @@ function InfoProvider.sectionsForTopOfDialog(viewFactory, properties)
         spacing = vf:label_spacing(),
         vf:static_text {
           title = LOC '$$$/ComputerVisionTagging/preferences/ignoreKeywordTreeBranches=Ignore keywords branches:',
-          tooltip = 'Comma-separated list of keyword terms to ignore (including chilren and descendants).',
+          tooltip = 'Comma-separated list of keyword terms to ignore (including children and descendants).',
           alignment = 'left',
         },
         viewFactory:edit_field {
-          tooltip = 'Comma-separated list of keyword terms to ignore (including chilren and descendants).',
+          tooltip = 'Comma-separated list of keyword terms to ignore (including children and descendants).',
           width_in_chars = 35,
           height_in_lines = 4,
           enabled = true,

--- a/ai_tagging.lrdevplugin/PluginInfoProvider.lua
+++ b/ai_tagging.lrdevplugin/PluginInfoProvider.lua
@@ -111,11 +111,11 @@ function InfoProvider.sectionsForTopOfDialog(viewFactory, properties)
         spacing = vf:label_spacing(),
         vf:static_text {
           title = LOC '$$$/ComputerVisionTagging/preferences/ignoreKeywordTreeBranches=Ignore keywords branches:',
-          tooltip = 'Comma-separated list of keyword terms to ignore (including children and descendants).',
+          tooltip = 'Comma-separated list of keyword terms to ignore (including chilren and descendants).',
           alignment = 'left',
         },
         viewFactory:edit_field {
-          tooltip = 'Comma-separated list of keyword terms to ignore (including children and descendants).',
+          tooltip = 'Comma-separated list of keyword terms to ignore (including chilren and descendants).',
           width_in_chars = 35,
           height_in_lines = 4,
           enabled = true,
@@ -214,6 +214,15 @@ function InfoProvider.sectionsForTopOfDialog(viewFactory, properties)
           unchecked_value = false,
           value = bind 'tag_window_show_services',
         },
+	  },
+	  vf:row {
+        spacing = vf:control_spacing(),
+        vf:checkbox {
+          title = 'Add keyword *and* keyword parents',
+          checked_value = true,
+          unchecked_value = false,
+          value = bind 'tag_add_keyword_parents',
+        },	
       },
       vf:row {
         spacing = vf:control_spacing(),

--- a/ai_tagging.lrdevplugin/PluginInfoProvider.lua
+++ b/ai_tagging.lrdevplugin/PluginInfoProvider.lua
@@ -138,7 +138,23 @@ function InfoProvider.sectionsForTopOfDialog(viewFactory, properties)
           alightment = 'left',
           value = bind 'parent_tag',
         },
-      },    
+      }, 
+	  vf:row {
+        spacing = vf:control_spacing(),
+        vf:static_text {
+          title = 'Keyword parsing timeout',
+          tooltip = 'Increase the timeout value if you encounter problem processing catalog keywords (useful for large keyword hierarchies/older hardware)',
+        },
+        vf:edit_field {
+          value = bind 'keyword_parsing_timeout',
+          tooltip = 'Seconds to timeout',
+          min = 1,
+          max = 900,
+          width_in_chars = 3,
+          increment = 1,
+          precision = 0,
+        }
+      },
       vf:row {
         spacing = vf:control_spacing(),
         vf:static_text {
@@ -218,7 +234,7 @@ function InfoProvider.sectionsForTopOfDialog(viewFactory, properties)
 	  vf:row {
         spacing = vf:control_spacing(),
         vf:checkbox {
-          title = 'Add keyword *and* keyword parents',
+          title = 'Add keyword *and* keyword parent(s)',
           checked_value = true,
           unchecked_value = false,
           value = bind 'tag_add_keyword_parents',

--- a/ai_tagging.lrdevplugin/Tagging.lua
+++ b/ai_tagging.lrdevplugin/Tagging.lua
@@ -100,12 +100,14 @@ function Tagging.tagPhotos(tagsByPhoto, tagSelectionsByPhoto, parentProgress)
             local checkboxState = tagSelectionsByPhoto[photo][tagName][i];
             local keyword = _G.AllKeys[tagLower][i];
             if numKeysByName == 1 and (checkboxState ~= LUTILS.inTable(tagLower, existingPhotoKeywordNamesLower)) then
-              KwUtils.addOrRemoveKeyword(photo, keyword, checkboxState)
-            elseif numKeysByName > 1 then
+				if prefs.tag_add_keyword_parents then KwUtils.addOrRemoveKeyword(photo, keyword, checkboxState)
+				else KwUtils.addOrRemoveKeywordWithoutParents(photo, keyword, checkboxState) end
+			elseif numKeysByName > 1 then
             -- We need to use more accurate (less performant) means to verify the actual keyword
             -- is (or is not) already associated with the photo.
               if checkboxState ~= KwUtils.hasKeywordById(photo, keyword) then
-                KwUtils.addOrRemoveKeyword(photo, keyword, checkboxState)
+                if prefs.tag_add_keyword_parents then KwUtils.addOrRemoveKeyword(photo, keyword, checkboxState)
+				else KwUtils.addOrRemoveKeywordWithoutParents(photo, keyword, checkboxState) end
               end
             end
           end


### PR DESCRIPTION
I've added an option to change the default keyword adding behaviour: By default the keyword from the Cloud API **and** every corresponding parent keyword is added. In my opinion this pollutes the keyword field in Lightroom as parent keywords will automatically be added on export (if the user chooses the "Include on export" option).

Additionally, I've added an option to increase the keyword parsing timeout.

This is my first time changing something in LUA/Lightroom, so please feel free to fix any mistake/ignored naming convention etc.

Cheers,
Ben